### PR TITLE
use upstream image-output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -590,8 +590,9 @@
       }
     },
     "image-output": {
-      "version": "git+https://github.com/freaktechnik/image-output.git#4296a02fe31d9c52245f988dba859ae8c8991d97",
-      "from": "git+https://github.com/freaktechnik/image-output.git#4296a02fe31d9c52245f988dba859ae8c8991d97",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/image-output/-/image-output-2.4.1.tgz",
+      "integrity": "sha512-Ms9lK9TXBv+x6ACNWF+2eaIXbArG1vQbYNe50LeRnNj1cExdCyekFUMAf5LVsp0nvnnTXJcTie3DrhXJ4AWTaA==",
       "requires": {
         "chalk": "^2.4.1",
         "get-ext": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/tim-hellhake/sonos-adapter#readme",
   "dependencies": {
-    "image-output": "git+https://github.com/freaktechnik/image-output.git#4296a02fe31d9c52245f988dba859ae8c8991d97",
+    "image-output": "^2.4.1",
     "image-pixels": "^2.2.2",
     "image-type": "^4.1.0",
     "is-browser": "^2.1.0",


### PR DESCRIPTION
`image-output` finally merged and published the bugfix.